### PR TITLE
docs: include link to Waitlisty codebase repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repo is a place to file bugs you encounter when using [Waitlisty](https://apps.cis.upenn.edu/waitlist), the waitlist system for a variety of Penn courses. There is no source code here.
 
 Documentation on *using* Waitlisty can be found in [the CIS Advising Handbook](https://advising.cis.upenn.edu/waitlist).
+
+The Waitlisty codebase is hosted in a private repository [https://github.com/upenn/cis-waitlist](https://github.com/upenn/cis-waitlist).


### PR DESCRIPTION
Added link to the Waitlisty codebase repository.